### PR TITLE
Add PaperMod theme as a Git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "themes/hello-friend-ng-hz"]
 	path = themes/hello-friend-ng-hz
 	url = https://github.com/krshrimali/hugo-theme-hello-friend-ng-hz.git
+[submodule "themes/PaperMod"]
+	path = themes/PaperMod
+	url = https://github.com/adityatelange/hugo-PaperMod.git

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 ## Theme Information
 
 * The blog uses the [PaperMod](https://github.com/adityatelange/hugo-PaperMod) theme - a simple, fast, and developer-friendly theme.
+* The theme is included as a Git submodule. When cloning this repository, use `git clone --recurse-submodules` to ensure the theme is included.
 * Features include:
   * Light/dark mode toggle (automatically adapts to user's system preferences by default)
   * Responsive design optimized for all device sizes

--- a/config.toml
+++ b/config.toml
@@ -66,6 +66,7 @@ mediaType = "application/toml"
   ShowCodeCopyButtons = true
   ShowRssButtonInSectionTermList = true
   ShowToc = true
+  disableSpecial1stPost = true
 
   # Home page settings - commented out to show posts directly
   # [params.homeInfoParams]


### PR DESCRIPTION
Updated the README to include cloning instructions for submodules. Added PaperMod theme configuration to `.gitmodules` and adjusted `config.toml` to disable special formatting for the first post.