### PR TITLE
Add PR validation workflow using GitHub Actions

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,0 +1,34 @@
+name: PR Validation
+
+on:
+  pull_request:
+    branches:
+      - main  # Set this to the branch you want to validate PRs against
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source repository
+        uses: actions/checkout@v3
+        with:
+          submodules: true  # Fetch Hugo themes (true OR recursive)
+          fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
+
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v2
+        with:
+          hugo-version: 'latest'
+          extended: true
+
+      - name: Build
+        run: hugo --minify
+
+      - name: Check build status
+        run: |
+          if [ $? -eq 0 ]; then
+            echo "Build successful!"
+          else
+            echo "Build failed!"
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -21,6 +21,15 @@
 
 The blog uses GitHub Actions to ensure that the website builds without errors before pull requests are merged to the main branch. This helps catch any issues early in the development process.
 
+The PR validation workflow:
+1. Automatically runs on every pull request to the main branch
+2. Checks out the repository with all submodules (ensuring themes are properly included)
+3. Sets up Hugo with the latest version and extended support
+4. Attempts to build the site with `hugo --minify`
+5. Fails the check if the build process encounters any errors
+
+This ensures that all PRs can be safely merged without breaking the site build.
+
 ### Automatic Deployment
 
 The blog is automatically deployed to [krshrimali.github.io](https://krshrimali.github.io) whenever changes are pushed to the main branch, using GitHub Actions.


### PR DESCRIPTION
Document PR validation steps in the README and introduce a workflow to verify builds on pull requests. Ensure PRs don't break the site build by setting up GitHub Actions for Hugo-based validation.