### PR TITLE
Adjust template width for mobile view

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -1,3 +1,24 @@
 :root {
-    --main-width: 50%;
+    --main-width: 720px; /* Default desktop width */
+}
+
+/* Tablet and smaller desktop screens */
+@media screen and (max-width: 1024px) {
+    :root {
+        --main-width: 90%; /* Use more of the available width */
+    }
+}
+
+/* Mobile screens */
+@media screen and (max-width: 768px) {
+    :root {
+        --main-width: 95%; /* Use almost full width on mobile for better readability */
+    }
+}
+
+/* Very small mobile screens */
+@media screen and (max-width: 480px) {
+    :root {
+        --main-width: 98%; /* Maximum width utilization on very small screens */
+    }
 }

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -1,3 +1,24 @@
 :root {
-    --main-width: 50%;
+    --main-width: 720px; /* Default desktop width */
+}
+
+/* Tablet and smaller desktop screens */
+@media screen and (max-width: 1024px) {
+    :root {
+        --main-width: 90%; /* Use more of the available width */
+    }
+}
+
+/* Mobile screens */
+@media screen and (max-width: 768px) {
+    :root {
+        --main-width: 95%; /* Use almost full width on mobile for better readability */
+    }
+}
+
+/* Very small mobile screens */
+@media screen and (max-width: 480px) {
+    :root {
+        --main-width: 98%; /* Maximum width utilization on very small screens */
+    }
 }


### PR DESCRIPTION
Adjust template width for improved mobile responsiveness.

The previous custom CSS set `--main-width` to `50%`, which resulted in a very narrow content area on mobile devices. This PR changes the `--main-width` to be `720px` by default for desktop and introduces media queries to use `90%`, `95%`, and `98%` of the screen width for tablet, mobile, and very small mobile screens respectively, significantly improving readability and user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-521ad8ce-8925-4e4c-992e-7d5f19cb8209">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-521ad8ce-8925-4e4c-992e-7d5f19cb8209">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>